### PR TITLE
Add Celery scheduler

### DIFF
--- a/src/trip_sniper/pipeline.py
+++ b/src/trip_sniper/pipeline.py
@@ -136,3 +136,17 @@ def run_pipeline(destinations: Sequence[str], dates: Sequence[str], database_url
                     _upsert_offer(session, offer, score)
         session.commit()
 
+
+
+def run() -> None:
+    """Entry point used by the scheduler.
+
+    Destinations and dates are read from the environment variables
+    ``DESTINATIONS`` and ``DATES`` (comma separated).
+    """
+    dests = os.getenv("DESTINATIONS")
+    dates = os.getenv("DATES")
+    if not dests or not dates:
+        raise RuntimeError("DESTINATIONS and DATES must be set")
+    run_pipeline(dests.split(","), dates.split(","))
+

--- a/src/trip_sniper/scheduler.py
+++ b/src/trip_sniper/scheduler.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from celery import Celery
+from celery.schedules import crontab
+
+from . import pipeline
+
+# Celery application configured with Redis broker
+BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+app = Celery("trip_sniper", broker=BROKER_URL)
+
+
+@app.on_after_configure.connect
+def setup_periodic_tasks(sender, **kwargs) -> None:
+    """Register periodic tasks."""
+    sender.add_periodic_task(
+        crontab(minute=0, hour="*"),
+        run_pipeline_task.s(),
+        name="run pipeline hourly",
+    )
+
+
+@app.task(bind=True, max_retries=3, default_retry_delay=300, acks_late=True)
+def run_pipeline_task(self) -> None:
+    """Run the data pipeline. Idempotent due to upserts."""
+    try:
+        pipeline.run()
+    except Exception as exc:  # noqa: BLE001
+        raise self.retry(exc=exc)


### PR DESCRIPTION
## Summary
- add a Celery scheduler configured with Redis
- expose a `run()` entry point for the pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68558443ce08832d99403f425da1b8b9