### PR TITLE
Add configurable steal_score weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,43 @@ poetry run python -m trip_sniper.service
 
 This command will execute the main service package. Adjust the entry point as your implementation evolves.
 
+## Scoring Configuration
+
+The `steal_score` algorithm combines several feature scores using a weight table.
+Default weights are:
+
+```json
+{
+    "discount_pct": 0.25,
+    "absolute_price_score": 0.2,
+    "hotel_quality": 0.2,
+    "flight_comfort": 0.15,
+    "urgency_score": 0.05,
+    "novelty_score": 0.05,
+    "category_match": 0.1
+}
+```
+
+Weights can be overridden via the environment. Provide a JSON string in
+`STEAL_SCORE_WEIGHTS` or a path to a JSON file in `STEAL_SCORE_WEIGHTS_FILE`.
+Missing keys fall back to the defaults.
+
+Example using an environment variable:
+
+```bash
+export STEAL_SCORE_WEIGHTS='{"discount_pct": 0.3, "absolute_price_score": 0.15}'
+```
+
+Example JSON file (`weights.json`):
+
+```json
+{
+    "discount_pct": 0.3,
+    "absolute_price_score": 0.15
+}
+```
+
+```bash
+export STEAL_SCORE_WEIGHTS_FILE=weights.json
+```
+


### PR DESCRIPTION
## Summary
- load steal_score weights from `STEAL_SCORE_WEIGHTS` or `STEAL_SCORE_WEIGHTS_FILE`
- adjust feature test to use runtime weights
- document weight customization in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68594eae6518832d8b2edc56ce48088d