### PR TITLE
Add cron env var for scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,14 @@ Example JSON file (`weights.json`):
 export STEAL_SCORE_WEIGHTS_FILE=weights.json
 ```
 
+## Scheduler
+
+`src/trip_sniper/scheduler.py` starts a Celery beat process that triggers the
+data pipeline once per hour by default. To change the schedule, provide a
+standard five-field cron expression in the `RUN_PIPELINE_CRON` environment
+variable. The value is parsed using `celery.schedules.crontab`.
+
+```bash
+export RUN_PIPELINE_CRON="0 */6 * * *"  # run every six hours
+```
+

--- a/src/trip_sniper/scheduler.py
+++ b/src/trip_sniper/scheduler.py
@@ -10,14 +10,31 @@ from . import pipeline
 BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
 app = Celery("trip_sniper", broker=BROKER_URL)
 
+# Optional cron expression for pipeline execution
+RUN_PIPELINE_CRON = os.getenv("RUN_PIPELINE_CRON")
+
 
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs) -> None:
     """Register periodic tasks."""
+    cron_expr = RUN_PIPELINE_CRON
+    if cron_expr:
+        fields = cron_expr.split()
+        if len(fields) != 5:
+            raise ValueError("RUN_PIPELINE_CRON must have 5 fields")
+        schedule = crontab(
+            minute=fields[0],
+            hour=fields[1],
+            day_of_month=fields[2],
+            month_of_year=fields[3],
+            day_of_week=fields[4],
+        )
+    else:
+        schedule = crontab(minute=0, hour="*")
     sender.add_periodic_task(
-        crontab(minute=0, hour="*"),
+        schedule,
         run_pipeline_task.s(),
-        name="run pipeline hourly",
+        name="run pipeline",
     )
 
 


### PR DESCRIPTION
## Summary
- make pipeline schedule configurable via `RUN_PIPELINE_CRON`
- document scheduler configuration in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68595117e1b0832d90e479c9436de334