### PR TITLE
Implement Session context manager methods

### DIFF
--- a/sqlalchemy/orm/__init__.py
+++ b/sqlalchemy/orm/__init__.py
@@ -2,6 +2,15 @@ class Session:
     def __init__(self, *args, **kwargs):
         pass
 
+    def __enter__(self):
+        """Enter the runtime context related to this object."""
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        """Exit the runtime context and close the session."""
+        self.close()
+        return False
+
     def execute(self, *args, **kwargs):  # pragma: no cover
         return []
 
@@ -14,11 +23,17 @@ class Session:
     def add_all(self, items):  # pragma: no cover
         pass
 
+    def add(self, item):  # pragma: no cover - simple stub
+        pass
+
     def commit(self):  # pragma: no cover
         pass
 
     def close(self):  # pragma: no cover
         pass
+
+    def get(self, model, identity):  # pragma: no cover - simple stub
+        return None
 
 
 def sessionmaker(bind=None):


### PR DESCRIPTION
## Summary
- extend stub Session with context manager support
- add no-op add and get methods for use in pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859ca3b309c832dab9e7cbf0414f567