### PR TITLE
Update running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ This project provides the skeleton for the `trip_sniper` service managed with [P
 
 ## Running
 
-To run the service module:
+To start the FastAPI application defined in `src/trip_sniper/service/app.py`:
 
 ```bash
-poetry run python -m trip_sniper.service
+poetry run python -m trip_sniper.service.app
 ```
 
-This command will execute the main service package. Adjust the entry point as your implementation evolves.
+This command runs the service's main FastAPI app.
 
 ## Scoring Configuration
 


### PR DESCRIPTION
## Summary
- update running instructions in README to use `trip_sniper.service.app`
- clarify that this command starts the FastAPI application

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6859d6526a4c832da78081ab94611b9b