### PR TITLE
Add environment variable support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+AMADEUS_HOST=https://api.amadeus.com
+AMADEUS_API_KEY=your_amadeus_api_key
+AMADEUS_API_SECRET=your_amadeus_api_secret
+ORIGIN_IATA=WAW

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ poetry run python -m trip_sniper.service.app
 
 This command runs the service's main FastAPI app.
 
+## Environment Variables
+
+The service relies on several environment variables for external API access and
+configuration. Create a `.env` file or export the variables in your shell. Key
+settings include:
+
+```ini
+AMADEUS_HOST=https://api.amadeus.com     # or https://test.api.amadeus.com
+AMADEUS_API_KEY=xxxxxxxxxxxxxxxx
+AMADEUS_API_SECRET=yyyyyyyyyyyyyyyy
+ORIGIN_IATA=WAW                          # default departure airport
+```
+
 ## Scoring Configuration
 
 The `steal_score` algorithm combines several feature scores using a weight table.

--- a/src/trip_sniper/fetchers/skyscanner.py
+++ b/src/trip_sniper/fetchers/skyscanner.py
@@ -128,9 +128,10 @@ class SkyscannerFetcher:
         offers: List[Offer] = []
         pages_fetched = 0
 
+        origin = os.getenv("ORIGIN_IATA", "WAW")
         while True:
             params = {
-                "origin": "WAW",
+                "origin": origin,
                 "destination": destination,
                 "date": date,
                 "page": state.page,
@@ -158,9 +159,10 @@ class SkyscannerFetcher:
         state = _PaginationState()
         offers: List[Offer] = []
 
+        origin = os.getenv("ORIGIN_IATA", "WAW")
         while True:
             params = {
-                "origin": "WAW",
+                "origin": origin,
                 "destination": destination,
                 "date": date,
                 "page": state.page,


### PR DESCRIPTION
## Summary
- support configurable origin airport for Skyscanner fetcher via `ORIGIN_IATA`
- document environment variables
- provide `.env.example` file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685bce1fb958832d9d995768ba93e36e