### PR TITLE
Add Amadeus client patch test

### DIFF
--- a/tests/test_amadeus_fetcher.py
+++ b/tests/test_amadeus_fetcher.py
@@ -1,5 +1,6 @@
 import pytest
 from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 from trip_sniper.fetchers.amadeus import AmadeusFlightFetcher
 from trip_sniper.models import Offer
@@ -62,3 +63,53 @@ def test_fetch_offers_uses_env_origin(monkeypatch):
     fetcher, dummy = make_fetcher(monkeypatch, data, {"X-RateLimit-Remaining": "1"})
     fetcher.fetch_offers("LON", "2024-01-01")
     assert dummy.params["originLocationCode"] == "XYZ"
+
+
+def test_fetch_offers_with_patched_client():
+    dummy_offers = [
+        {
+            "id": "O1",
+            "price": {"grandTotal": "100"},
+            "itineraries": [
+                {
+                    "segments": [
+                        {
+                            "departure": {"at": "2025-07-01T10:00:00"},
+                            "arrival": {"at": "2025-07-01T12:00:00"},
+                        }
+                    ]
+                }
+            ],
+        },
+        {
+            "id": "O2",
+            "price": {"grandTotal": "200"},
+            "itineraries": [
+                {
+                    "segments": [
+                        {
+                            "departure": {"at": "2025-07-01T13:00:00"},
+                            "arrival": {"at": "2025-07-01T14:00:00"},
+                        },
+                        {
+                            "departure": {"at": "2025-07-01T15:00:00"},
+                            "arrival": {"at": "2025-07-01T16:00:00"},
+                        },
+                    ]
+                }
+            ],
+        },
+    ]
+
+    with patch("trip_sniper.fetchers.amadeus.amadeus_client.Client") as MockClient:
+        client_instance = MagicMock()
+        MockClient.return_value = client_instance
+        client_instance.shopping.flight_offers_search.get.return_value.data = dummy_offers
+
+        fetcher = AmadeusFlightFetcher(api_key="k", api_secret="s")
+        offers = fetcher.fetch_offers("BCN", "2025-07-01")
+
+        assert isinstance(offers[0], Offer)
+        assert offers[0].id == "O1"
+        assert offers[0].price_per_person == 100.0
+        assert offers[0].direct is True


### PR DESCRIPTION
## Summary
- extend `tests/test_amadeus_fetcher.py` with a new test that patches the amadeus client
- simulate two offers and verify mapping of offer fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685beab07fc4832d88ca93bbdf94c628