### PR TITLE
Allow running pipeline with flights only

### DIFF
--- a/src/trip_sniper/fetchers/amadeus.py
+++ b/src/trip_sniper/fetchers/amadeus.py
@@ -8,8 +8,21 @@ import time
 from datetime import datetime
 from typing import Any, List, Optional
 
-import amadeus as amadeus_client
-from amadeus import ResponseError
+try:  # pragma: no cover - optional dependency for tests
+    import amadeus as amadeus_client
+    from amadeus import ResponseError
+except Exception:  # pragma: no cover - allow tests without package
+    class _DummyClient:
+        def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
+            pass
+
+    class _DummyModule:
+        Client = _DummyClient
+
+    amadeus_client = _DummyModule()  # type: ignore
+
+    class ResponseError(Exception):
+        pass
 
 from ..models import Offer
 
@@ -38,6 +51,8 @@ class AmadeusFlightFetcher:
     @property
     def amadeus(self) -> amadeus_client.Client:
         if self._amadeus is None:
+            if amadeus_client is None:
+                raise RuntimeError("amadeus package not installed")
             self._amadeus = amadeus_client.Client(
                 client_id=self.api_key,
                 client_secret=self.api_secret,


### PR DESCRIPTION
## Summary
- make Amadeus client optional so tests run without the package
- support `flights_only` mode in `run_pipeline`
- expose environment variable `FLIGHTS_ONLY` in `run`
- update `_upsert_offer` to create ORM objects without kwargs
- add unit test for flights-only pipeline

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685d9c8d02dc832d9e3298358107578e